### PR TITLE
Python api

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "extern/spdlog"]
 	path = extern/spdlog
 	url = git@github.com:gabime/spdlog.git
+[submodule "extern/--force"]
+	path = extern/--force
+	url = git@github.com:pybind/pybind11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "extern/spdlog"]
 	path = extern/spdlog
 	url = git@github.com:gabime/spdlog.git
-[submodule "extern/--force"]
-	path = extern/--force
+[submodule "extern/pybind11"]
+	path = extern/pybind11
 	url = git@github.com:pybind/pybind11.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,9 @@ add_subdirectory(extern/doctest EXCLUDE_FROM_ALL)
 add_subdirectory(extern/kokkos EXCLUDE_FROM_ALL)
 add_subdirectory(extern/json EXCLUDE_FROM_ALL)
 add_subdirectory(extern/spdlog EXCLUDE_FROM_ALL)
+add_subdirectory(extern/pybind11 EXCLUDE_FROM_ALL)
 
-
+# tests configuration
 option(Ibis_BUILD_TESTS "Build Ibis CI tests" ON)
 if (Ibis_BUILD_TESTS)
     enable_testing()
@@ -38,6 +39,7 @@ else()
     add_compile_options( -DDOCTEST_CONFIG_DISABLE )
 endif(Ibis_BUILD_TESTS)
 
+# be picky about warnings
 add_compile_options( -Wall -Wextra -Wpedantic )
 
 # add all the source code
@@ -48,6 +50,7 @@ add_subdirectory(src/finite_volume)
 add_subdirectory(src/ibis/)
 add_subdirectory(src/solvers)
 add_subdirectory(src/io)
+add_subdirectory(src/python)
 add_subdirectory(share)
 
 # allow packaging to distribute a pre-compiled 

--- a/src/ibis/src/commands/ibis_py_utils.py
+++ b/src/ibis/src/commands/ibis_py_utils.py
@@ -1,7 +1,6 @@
 import json
-import os
+from python_api import GasState, Vector3
 
-IBIS = os.environ.get("IBIS")
 
 def read_defaults(defaults_dir, file_name):
     with open(f"{defaults_dir}/{file_name}", "r") as defaults:
@@ -10,35 +9,36 @@ def read_defaults(defaults_dir, file_name):
 
 class FlowState:
     # __slots__ = ["p", "T", "rho" "vx", "vy", "vz"]
+    __slots__ = ["gas", "vel"]
 
     def __init__(self, p=None, T=None, rho=None, vx=0.0, vy=0.0, vz=0.0):
-        if p:
-            self.p = p
-        if T:
-            self.T = T
-        if rho:
-            self.rho = rho
-        self.vx = vx
-        self.vy = vy
-        self.vz = vz
+        self.vel = Vector3()
+        self.vel.x = vx
+        self.vel.y = vy
+        self.vel.z = vz
 
-        if not p:
-            if not T or not rho:
-                raise Exception("Need two of rho, T, and p")
-            self.p = self.rho * 287 * T
+        self.gas = GasState()
+        if p and T:
+            self.gas.p = p
+            self.gas.T = T
+            self.gas.rho = p / (287 * T)   
 
-        if not T:
-            if not rho or not p:
-                raise Exception("Need two of rho, T, and p")
-            self.T = self.p / (self.rho * 287)
+        elif p and rho:
+            self.gas.p = p
+            self.gas.rho = rho
+            self.gas.T = p / (rho * 287)
 
-        if not rho:
-            if not T or not p:
-                raise Exception("Need two of rho, T, and p")
-            self.rho = self.p / (287 * self.T)
+        elif rho and T:
+            self.gas.rho = rho
+            self.gas.T = T
+            self.gas.p = rho * 287.0 * T
+
+        else:
+            raise Exception("Need two of rho, T, and p")
+
 
     def as_dict(self):
         return {
-            "p": self.p, "T": self.T, 
-            "vx": self.vx, "vy": self.vy, "vz": self.vz
+            "p": self.gas.p, "T": self.gas.T, 
+            "vx": self.vel.x, "vy": self.vel.y, "vz": self.vel.z
         }

--- a/src/ibis/src/commands/prep.py
+++ b/src/ibis/src/commands/prep.py
@@ -127,12 +127,12 @@ class Block:
 
         if type(self._initial_condition) == FlowState:
             for _ in range(self.number_cells):
-                temp.write(f"{self._initial_condition.T:.16e}\n")
-                pressure.write(f"{self._initial_condition.p:.16e}\n")
-                vx.write(f"{self._initial_condition.vx:.16e}\n")
-                vy.write(f"{self._initial_condition.vy:.16e}\n")
+                temp.write(f"{self._initial_condition.gas.T:.16e}\n")
+                pressure.write(f"{self._initial_condition.gas.p:.16e}\n")
+                vx.write(f"{self._initial_condition.vel.x:.16e}\n")
+                vy.write(f"{self._initial_condition.vel.y:.16e}\n")
                 if self.dim == 3:
-                    vz.write(f"{self._initial_condition.vz:.16e}\n")
+                    vz.write(f"{self._initial_condition.vel.z:.16e}\n")
         json.dump({"time": 0.0}, meta_data, indent=4) 
         times.write("0000\n")
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,5 +1,6 @@
 pybind11_add_module(
 	python_api
+	NO_EXTRAS
 	src/python_api.cpp 
 )
 set_target_properties(python_api PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -2,7 +2,7 @@ pybind11_add_module(
 	python_api
 	src/python_api.cpp 
 )
-set_property(TARGET python_api PROPERTY CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+set_target_properties(python_api PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 
 target_link_libraries(
 	python_api

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,0 +1,13 @@
+pybind11_add_module(
+	python_api
+	src/python_api.cpp 
+)
+set_property(TARGET python_api PROPERTY CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+
+target_link_libraries(
+	python_api
+	PRIVATE 
+	Kokkos::kokkos
+)
+
+install(TARGETS python_api DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/python/src/python_api.cpp
+++ b/src/python/src/python_api.cpp
@@ -1,0 +1,19 @@
+#include <pybind11/pybind11.h>
+#include "../../gas/src/gas_state.h"
+#include "../../util/src/vector3.h"
+
+PYBIND11_MODULE(python_api, m) {
+    m.doc() = "Aeolus python module";
+
+    pybind11::class_<GasState<double>>(m, "GasState")
+        .def(pybind11::init())
+        .def_readwrite("p", &GasState<double>::pressure, "pressure (Pa)")
+        .def_readwrite("T", &GasState<double>::temp, "temperature (K)")
+        .def_readwrite("rho", &GasState<double>::rho, "density (kg/m^3)");
+
+    pybind11::class_<Vector3<double>>(m, "Vector3")
+        .def(pybind11::init())
+        .def_readwrite("x", &Vector3<double>::x, "x")
+        .def_readwrite("y", &Vector3<double>::y, "y")
+        .def_readwrite("z", &Vector3<double>::z, "z");
+}


### PR DESCRIPTION
This pull request adds a dependancy on pybind11 to make a python api to some of the c++ objects.  The idea is this will expose some functionality, especially for gas models, to python at pre/post-processing time.

Currently, just gas state and vector3 objects are exposed to python, but the machinery is set up now.