### PR TITLE
fix compile for ROCM on bunya

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_subdirectory(extern/doctest EXCLUDE_FROM_ALL)
 add_subdirectory(extern/kokkos EXCLUDE_FROM_ALL)
 add_subdirectory(extern/json EXCLUDE_FROM_ALL)
 add_subdirectory(extern/spdlog EXCLUDE_FROM_ALL)
+find_package(Python 3.11 COMPONENTS Interpreter Development REQUIRED)
 add_subdirectory(extern/pybind11 EXCLUDE_FROM_ALL)
 
 # tests configuration

--- a/src/ibis/CMakeLists.txt
+++ b/src/ibis/CMakeLists.txt
@@ -17,5 +17,6 @@ target_link_libraries(
 	runtime_dirs
 	spdlog::spdlog
 	solver
+	stdc++fs
 )
 install(TARGETS ibis DESTINATION ${CMAKE_INSTALL_BIN_DIR})


### PR DESCRIPTION
Just putting this here to document things that needed to be done to build this on bunya for an AMD gpu.

**Fixes**
1. `c++ std::filesystem` wasn't linking properly. Adding `stdc++fs` to `target_link_libraries` in `src/ibic/CMakeLists.txt` fixed this. [See here](https://stackoverflow.com/questions/44476810/build-project-with-experimental-filesystem-using-cmake)
2. `pybind11` wasn't finding `Python.h`, even with a python module loaded. Adding an invocation for the CMake `FindPython` module in the root `CMakeLists.txt` fixed it.
3. Set `CMAKE_CXX_COMPILER=amdclang++`.
4.It appears `module load rocm/5.7.1` doesn't properly set `ROCM_PATH`. Doing this is the final step to make everything work. See the bash script below.

```bash
#!/usr/bin/env bash

# command used to start interactive session for build
: '
salloc \
  --nodes=1 \
  --ntasks-per-node=1 \
  --cpus-per-task=96 \
  --mem=128G \
  --job-name=ibis_compile \
  --partition=gpu_rocm \
  --gres=gpu:mi210:1 \
  --account=a_hypersonics \
  srun \
  --export=PATH,TERM,HOME,LANG \
  --pty /bin/bash
'

# command used to load modules
: '
module load \
  cmake/3.26.3-gcccore-12.3.0 \
  rocm/5.7.1 \
  python/3.11.3-gcccore-12.3.0
'

# required for Kokkos to locate rocm
export ROCM_PATH=/opt/rocm

# build commands

cmake .. \
  -DKokkos_ENABLE_HIP=ON \
  -DCMAKE_CXX_COMPILER=amdclang++

# build and install
make install -j$(nproc)
```