### PR TITLE
delegate computation of areas/volumes to the util libary

### DIFF
--- a/src/grid/grid/interface.h
+++ b/src/grid/grid/interface.h
@@ -6,6 +6,7 @@
 #include <util/field.h>
 #include <util/id.h>
 #include <util/vector3.h>
+#include <util/geom.h>
 #include <grid/cell.h>
 #include <grid/grid_io.h>
 #include <grid/vertex.h>
@@ -226,41 +227,29 @@ public:
                 switch (shape(i)) {
                     case ElemType::Line: {
                         auto vertex_ids = this_vertex_ids[i];
-                        T x1 = vertices.positions().x(vertex_ids(0));
-                        T x2 = vertices.positions().x(vertex_ids(1));
-                        T y1 = vertices.positions().y(vertex_ids(0));
-                        T y2 = vertices.positions().y(vertex_ids(1));
-                        this_area(i) = Kokkos::sqrt((x2 - x1) * (x2 - x1) +
-                                                    (y2 - y1) * (y2 - y1));
+                        this_area(i) = Ibis::distance_between_points(
+                            vertices.positions(),
+                            vertex_ids(0),
+                            vertex_ids(1));
                         break;
                     }
                     case ElemType::Tri: {
                         auto vertex_ids = this_vertex_ids[i];
-                        T x1 = vertices.positions().x(vertex_ids(0));
-                        T x2 = vertices.positions().x(vertex_ids(1));
-                        T x3 = vertices.positions().y(vertex_ids(2));
-                        T y1 = vertices.positions().y(vertex_ids(0));
-                        T y2 = vertices.positions().z(vertex_ids(1));
-                        T y3 = vertices.positions().z(vertex_ids(2));
-                        T area =
-                            0.5 * Kokkos::fabs(x1 * (y2 - y3) + x2 * (y3 - y1) +
-                                               x3 * (y1 - y2));
-                        this_area(i) = area;
+                        this_area(i) = Ibis::area_of_triangle(
+                            vertices.positions(),
+                            vertex_ids(0),
+                            vertex_ids(1),
+                            vertex_ids(2));
                         break;
                     }
                     case ElemType::Quad: {
                         auto vertex_ids = this_vertex_ids[i];
-                        T x1 = vertices.positions().x(vertex_ids(0));
-                        T x2 = vertices.positions().x(vertex_ids(1));
-                        T x3 = vertices.positions().x(vertex_ids(2));
-                        T x4 = vertices.positions().x(vertex_ids(3));
-                        T y1 = vertices.positions().y(vertex_ids(0));
-                        T y2 = vertices.positions().y(vertex_ids(1));
-                        T y3 = vertices.positions().y(vertex_ids(2));
-                        T y4 = vertices.positions().y(vertex_ids(3));
-                        T area = x1 * y2 + x2 * y3 + x3 * y4 + x4 * y1 -
-                                 x2 * y1 - x3 * y2 - x4 * y3 - x1 * y4;
-                        this_area(i) = 0.5 * Kokkos::fabs(area);
+                        this_area(i) = Ibis::area_of_quadrilateral(
+                            vertices.positions(),
+                            vertex_ids(0),
+                            vertex_ids(1),
+                            vertex_ids(2),
+                            vertex_ids(3));
                         break;
                     }
                     case ElemType::Hex: {

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(util STATIC util/vector3.cpp util/id.cpp)
+add_library(util STATIC util/vector3.cpp util/id.cpp util/geom.cpp)
 target_link_libraries(util PUBLIC Kokkos::kokkos doctest)
 target_include_directories(util PUBLIC .)
 
@@ -7,7 +7,8 @@ if (Ibis_BUILD_TESTS)
     add_executable(util_unittest 
 		   test/unittest.cpp 
 		   util/vector3.cpp 
-		   util/id.cpp)
+		   util/id.cpp
+		   util/geom.cpp)
     # target_compile_options(util_unittest -g)
     target_link_libraries(util_unittest 	
 	PRIVATE Kokkos::kokkos doctest)

--- a/src/util/util/geom.cpp
+++ b/src/util/util/geom.cpp
@@ -1,0 +1,47 @@
+#include <doctest/doctest.h>
+#include "geom.h"
+
+const double EPS = 1e-15;
+
+TEST_CASE("distance_between_points") {
+    // allocate positions
+    Vector3s<double> pos {"pos", 10};
+    auto pos_host = pos.host_mirror();
+    for (int i = 0; i < 10; i++) {
+        pos_host.x(i) = 3*i;
+        pos_host.y(i) = i + 1;
+        pos_host.z(i) = 3*i - 5;
+    }
+    pos.deep_copy(pos_host);
+
+    // allocate the indecies we're going to query
+    Field<int> i ("i", 5);
+    auto i_host = i.host_mirror();
+    Field<int> j ("j", 5);
+    auto j_host = j.host_mirror();
+    i_host(0) = 0;
+    i_host(1) = 1;
+    i_host(2) = 5;
+    i_host(3) = 9;
+    i_host(4) = 2;
+    j_host(0) = 1;
+    j_host(1) = 2;
+    j_host(2) = 5;
+    j_host(3) = 9;
+    j_host(4) = 4;
+    i.deep_copy(i_host);
+    j.deep_copy(j_host);
+
+    // do the calculations
+    Field<double> results ("results", 5);
+    Kokkos::parallel_for("distance", 5, KOKKOS_LAMBDA (const int id) {
+        results(id) = Ibis::distance_between_points(pos, i(id), j(id));
+    });
+
+    // copy results back to the host
+    auto results_host = results.host_mirror();
+    results_host.deep_copy(results);
+
+    // check results
+    CHECK(Kokkos::abs(results_host(0) - Kokkos::sqrt(19)) <  EPS);
+}

--- a/src/util/util/geom.h
+++ b/src/util/util/geom.h
@@ -1,0 +1,70 @@
+#ifndef GEOM_H
+#define GEOM_H
+
+#include <Kokkos_Core.hpp>
+#include "Kokkos_Macros.hpp"
+#include "vector3.h"
+
+namespace Ibis {
+
+// Compute the distance from point i to point j
+// The i and j are indices into `positions`, which contains
+// the actual positions of all the points
+template <typename T, class Layout, class Space>
+KOKKOS_INLINE_FUNCTION
+T distance_between_points(const Vector3s<T, Layout, Space> &positions,
+                          const int i, const int j) {
+    T xi = positions.x(i);
+    T xj = positions.x(j);
+    T yi = positions.y(i);
+    T yj = positions.y(j);
+    T zi = positions.z(i);
+    T zj = positions.z(j);
+
+    T dx = xj - xi;
+    T dy = yj - yi;
+    T dz = zj - zi;
+
+    return Kokkos::sqrt(dx*dx + dy*dy + dz*dz);
+}
+
+// calculate the area of a triangle with vertices a, b, and c
+template <typename T, class Layout, class Space>
+KOKKOS_INLINE_FUNCTION
+T area_of_triangle(const Vector3s<T, Layout, Space> &pos,
+                   const int a, const int b, connst int c) {
+    // vector from a -> b
+    T ab_x = pos.x(b) - pos.x(a); 
+    T ab_y = pos.y(b) - pos.y(a);
+    T ab_z = pos.z(b) - pos.z(a);
+
+    // vector from a -> c
+    T ac_x = pos.x(c) - pos.x(a);
+    T ac_y = pos.y(c) - pos.y(a);
+    T ac_z = pos.z(c) - pos.z(a);
+
+    // cross product of the two vectors
+    T cross_x = ab_y * ac_z - ab_z * ac_y;
+    T cross_y = ab_z * ac_x - ab_x * ac_z;
+    T cross_z = ab_x * ac_y - ab_y * ac_x;
+
+    return 0.5 * Kokkos::sqrt(cross_x*cross_x + 
+                              cross_y*cross_y + 
+                              cross_z*cross_z);
+}
+
+// calculate the area of a quadrilateral with vertices
+// a, b, c, d
+template <typename T, class Layout, class Space>
+KOKKOS_INLINE_FUNCTION
+T area_of_quadrilateral(const Vector3s<T, Layout, Space> &pos,
+                        const int a, const int b, const int c, const int d) {
+    T a1 = area_of_triangle(pos, a, b, c);
+    T a2 = area_of_triangle(pos, a, c, d);
+    return a1 + a2;
+}
+
+
+}
+
+#endif

--- a/src/util/util/geom.h
+++ b/src/util/util/geom.h
@@ -32,7 +32,7 @@ T distance_between_points(const Vector3s<T, Layout, Space> &positions,
 template <typename T, class Layout, class Space>
 KOKKOS_INLINE_FUNCTION
 T area_of_triangle(const Vector3s<T, Layout, Space> &pos,
-                   const int a, const int b, connst int c) {
+                   const int a, const int b, const int c) {
     // vector from a -> b
     T ab_x = pos.x(b) - pos.x(a); 
     T ab_y = pos.y(b) - pos.y(a);
@@ -55,6 +55,8 @@ T area_of_triangle(const Vector3s<T, Layout, Space> &pos,
 
 // calculate the area of a quadrilateral with vertices
 // a, b, c, d
+// this computation could be bad if the quadrilateral
+// in question is concave...
 template <typename T, class Layout, class Space>
 KOKKOS_INLINE_FUNCTION
 T area_of_quadrilateral(const Vector3s<T, Layout, Space> &pos,


### PR DESCRIPTION
We had some repeated code in computing volumes and areas of cells and interfaces. This pull request moves the implementation of the volume/area else-where, and the cells/interfaces call the functions. 